### PR TITLE
Implement Type.hpp

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,8 +152,7 @@ Static fields are great. They often provide a pointer to an instance of the clas
 ```cpp
 const auto Asm_CSharp = Wrapper->get_image( "Assembly-CSharp.dll" );
 const auto player_handler = Asm_CSharp->get_class( "PlayerHandler" );
-const auto get_player_instance = player_handler->get_field( "Instance" );
-const auto player_instance = get_player_instance->get_static_value();
+const auto get_player_instance = player_handler->get_field( "Instance" )->get_as_static();
 ```
 
 If found, a pointer is returned, otherwise `nullptr` is returned.
@@ -161,7 +160,7 @@ If found, a pointer is returned, otherwise `nullptr` is returned.
 These methods may me chained if you don't need to use the initial class or field class for anything, like so:
 ```cpp
 const auto Asm_CSharp = Wrapper->get_image( "Assembly-CSharp.dll" );
-const auto player_instance = Asm_CSharp->get_class( "PlayerHandler" )->get_field( "Instance" )->get_static_value();
+const auto player_instance = Asm_CSharp->get_class( "PlayerHandler" )->get_field( "Instance" )->get_as_static();
 ```
 
 

--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@
   - [Initialization](#initialization)
   - [Getting An Image/DLL](#getting-an-imagedll)
   - [Getting A Class](#getting-a-class)
+  - [Getting All Fields Of A Class](#getting-all-fields-of-a-class)
   - [Getting A Static Field](#getting-a-static-field)
   - [Getting A Method Pointer](#getting-a-method-pointer)
   - [Invoking A Static Method](#invoking-a-static-method)
@@ -128,6 +129,22 @@ const auto player_handler = Asm_CSharp->get_class( "PlayerHandler" );
 If found, a pointer is returned, otherwise `nullptr` is returned.
 
 From here, PlayerHandler can provide you with various helper methods that allow you to get field and method pointers for fields and methods of the PlayerHandler class, as well as a helper method to invoke methods of the class.
+
+### Getting All Fields Of A Class
+Aetherim provides an easy way to get every field that a class has.
+
+In the example below, we get all fields of the PlayerHandler class, and print out each field's name and offset.
+
+```cpp
+const auto Asm_CSharp = Wrapper->get_image( "Assembly-CSharp.dll" );
+const auto player_handler = Asm_CSharp->get_class( "PlayerHandler" );
+const auto player = image->get_class( "PlayerHandler" );
+
+for ( const auto field : player->get_fields() )
+{
+  printf( "\t[Aetherim] PlayerHandler -> %s (0x%zx)\n", field->get_name(), field->get_offset() );
+}
+```
 
 ### Getting A Static Field
 Static fields are great. They often provide a pointer to an instance of the class. We can easily get the pointer to a class's static field like so:

--- a/main.cpp
+++ b/main.cpp
@@ -33,6 +33,9 @@ DWORD WINAPI Init( HMODULE module )
     printf( "\t[Aetherim] PlayerHandler -> %s (0x%zx)\n", field->get_name(), field->get_offset() );
   }
 
+  const auto player_instance = player->get_field( "Instance" )->get_as_static();
+  if ( player_instance != nullptr )
+    printf( "\t[Aetherim] PlayerHandler -> Static Instance (0x%zx)\n", reinterpret_cast<uintptr_t>( player_instance ) );
 
   Sleep( 60000 );
 

--- a/main.cpp
+++ b/main.cpp
@@ -28,12 +28,11 @@ DWORD WINAPI Init( HMODULE module )
   const auto player = image->get_class( "PlayerHandler" );
   printf( "\t[Aetherim] PlayerHandler -> %s (0x%Ix)\n\n", player->get_name(), reinterpret_cast<uintptr_t>( player ) );
 
-  for ( const auto field : static_cast<Class *>( player )->get_fields() )
+  for ( const auto field : player->get_fields() )
   {
-    const auto name = Il2cpp::get_field_name( field );
-
-    printf( "\t[Aetherim] %s (0x%zx)\n", name, player->get_field(name)->get_offset() );
+    printf( "\t[Aetherim] PlayerHandler -> %s (0x%zx)\n", field->get_name(), field->get_offset() );
   }
+
 
   Sleep( 60000 );
 

--- a/src/api.hpp
+++ b/src/api.hpp
@@ -19,6 +19,7 @@
 class Image;
 class Class;
 class Method;
+class Type;
 
 namespace Il2cpp
 {
@@ -76,10 +77,13 @@ namespace Il2cpp
 
   // types
   DEF_API( get_nested_types, Class *, (const void * klass, void *) );
+  DEF_API( get_type_attributes, uint32_t, ( const void * type ) );
   DEF_API( get_type_class, Class *, ( const void * type ) );
   DEF_API( get_type_name, const char *, ( const void * type ) );
   DEF_API( get_type_object, void *, ( const void * type ) );
   DEF_API( get_type_type, int, ( void * type ) );
+  DEF_API( get_type_equals, bool, ( Type * type_1, Type * type_2 ) );
+  DEF_API( get_type_is_byref, bool, ( Type * type ) );
 
   // methods
   DEF_API( method_call, void *, ( const Method * method, void * obj, void ** params, void ** excption ) );
@@ -171,10 +175,13 @@ namespace Il2cpp
 
     // types
     DEF_ADDR( get_nested_types, "il2cpp_class_get_nested_types", GameAssemblyHandle );
+    DEF_ADDR( get_type_attributes, "il2cpp_type_get_attrs", GameAssemblyHandle );
     DEF_ADDR( get_type_class, "il2cpp_type_get_class_or_element_class", GameAssemblyHandle );
     DEF_ADDR( get_type_name, "il2cpp_type_get_name", GameAssemblyHandle );
     DEF_ADDR( get_type_object, "il2cpp_type_get_object", GameAssemblyHandle );
     DEF_ADDR( get_type_type, "il2cpp_type_get_type", GameAssemblyHandle );
+    DEF_ADDR( get_type_equals, "il2cpp_type_equals", GameAssemblyHandle );
+    DEF_ADDR( get_type_is_byref, "il2cpp_type_is_byref", GameAssemblyHandle );
 
     // methods
     DEF_ADDR( method_call, "il2cpp_runtime_invoke", GameAssemblyHandle );

--- a/src/class.hpp
+++ b/src/class.hpp
@@ -18,7 +18,7 @@ private:
 public:
   Class() = default;
 
-  using fields_t = std::vector<void *>;
+  using fields_t = std::vector<Field *>;
 
   /**
    * Returns a pointer to the specified method.
@@ -76,7 +76,7 @@ public:
       if ( !field || field == NULL )
         continue;
 
-      m_fields[index++] = field;
+      m_fields[index++] = reinterpret_cast<Field *>( field );
     }
 
     return m_fields;

--- a/src/field.hpp
+++ b/src/field.hpp
@@ -14,20 +14,16 @@ public:
   Field() = default;
 
   /**
-   * Returns the value of a static field.
+   * Return a static field given a name.
    */
-  auto get_static_value() const -> void *
+  auto get_as_static() const -> void *
   {
     if ( Il2cpp::get_static_field == nullptr )
       return nullptr;
 
-    const auto field = Il2cpp::get_field( this, get_name() );
-    if ( !field )
-      return nullptr;
-
     void * val = NULL;
 
-    Il2cpp::get_static_field( field, &val );
+    Il2cpp::get_static_field( this, &val );
 
     return val;
   }

--- a/src/field.hpp
+++ b/src/field.hpp
@@ -48,14 +48,10 @@ public:
    */
   auto get_offset() const -> size_t
   {
-    if ( Il2cpp::get_field == nullptr )
+    if ( Il2cpp::get_field_offset == nullptr )
       return 0x0;
 
-    const void * field = Il2cpp::get_field( this, get_name() );
-    if ( field == nullptr )
-      return 0x0;
-
-    return Il2cpp::get_field_offset( field );
+    return Il2cpp::get_field_offset( this );
   }
 
   /**

--- a/src/type.hpp
+++ b/src/type.hpp
@@ -1,0 +1,94 @@
+#pragma once
+
+#include <Windows.h>
+#include <stdio.h>
+#include <cstdint>
+#include <iostream>
+#include <vector>
+
+#include "./api.hpp"
+
+class Class;
+
+class Type
+{
+public:
+  Type() = default;
+
+  /**
+   * Get a class of this type.
+   */
+  auto get_class() const -> Class *
+  {
+    if ( Il2cpp::get_type_class == nullptr )
+      return nullptr;
+
+    return Il2cpp::get_type_class( this );
+  }
+
+  /**
+   * Get the name of the type.
+   */
+  auto get_name() const -> const char *
+  {
+    if ( Il2cpp::get_type_name == nullptr )
+      return "Il2cpp::get_type_name is not supported.";
+
+    return Il2cpp::get_type_name( this );
+  }
+
+  /**
+   * Get an object of this type.
+   */
+  auto get_object() const -> void *
+  {
+    if ( Il2cpp::get_type_object == nullptr )
+      return nullptr;
+
+    return Il2cpp::get_type_object( this );
+  }
+
+  /**
+   * Get the type's type as an integer.
+   */
+  auto get_type() -> int
+  {
+    if ( Il2cpp::get_type_type == nullptr )
+      return -1;
+
+    return Il2cpp::get_type_type( this );
+  }
+
+  /**
+   * Get attributes of this type.
+   */
+  auto get_attributes() const -> uint32_t
+  {
+    if ( Il2cpp::get_type_attributes == nullptr )
+      return 0;
+
+    return Il2cpp::get_type_attributes( this );
+  }
+
+  /**
+   * Check if this type is the same as a different type.
+   */
+  auto compare_type( Type * type ) -> bool
+  {
+    if ( Il2cpp::get_type_equals == nullptr )
+      return false;
+
+    return Il2cpp::get_type_equals( this, type );
+  }
+
+  /**
+   * Check if this type is byref.
+   */
+  auto is_by_ref() -> bool
+  {
+    if ( Il2cpp::get_type_is_byref == nullptr )
+      return false;
+
+    return Il2cpp::get_type_is_byref( this );
+  }
+};


### PR DESCRIPTION
Type.hpp has been implemented, which provides a very basic wrapper for handling `Type` pointers that are gotten from other native IL2CPP methods.

On top of this basic wrapper, a couple of fixes have been implemented regarding class fields, specifically where getting all class fields and getting a class's static field would cause crashing due to an unnecessary check when processing the fields.

The README has been updated to reflect this.