### PR TITLE
Add Linux and MacOS example files 

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ Linux and MacOS users have the best ease-of-use and can just run the compile scr
 Windows users have a variety of options, all of which require additional tooling to compile the library.
 
 ### Compiling The Library
-There is an included script ([./compile.sh](`compile.sh`)) that should be used to compile the library.
+There is an included script ([./compile.sh](compile.sh)) that should be used to compile the library.
 
 #### Linux and MacOS
 You should be able to simply run the script and the library will be compiled.
@@ -68,7 +68,7 @@ A few different options are open for you.
 
 1. Install [Visual Studio](https://visualstudio.microsoft.com/) and compile through it.
 2. Install [Premake](https://premake.github.io/) and generate a project file, open the project file in the appropriate software, and compile that way.
-3. Install [MinGW](https://www.msys2.org/) and [WSL](https://learn.microsoft.com/en-us/windows/wsl/install) and run the [./compile.sh](`compile.sh`) script.
+3. Install [MinGW](https://www.msys2.org/) and [WSL](https://learn.microsoft.com/en-us/windows/wsl/install) and run the [./compile.sh](compile.sh) script.
 
 > Options 1 and 2 have been tested and are confirmed to work; option 3 has not been tested, but should work.
 
@@ -103,10 +103,13 @@ git rm <path-to-Aetherim>
 Included are some very basic examples of how to use this library, all of which can be found in the [./examples](examples/) directory.
 
 **Windows** [example file](examples/windows.cpp)
+
 **Linux** [example file](examples/linux.cpp)
+
 **Mac** [example file](examples/mac.cpp)
 
-> As of the most recent update, there is no Linux or Mac example files.
+
+> As of the most recent update, there is no usage example files for Linux or Mac.
 
 
 ### Initialization

--- a/README.md
+++ b/README.md
@@ -104,12 +104,10 @@ Included are some very basic examples of how to use this library, all of which c
 
 **Windows** [example file](examples/windows.cpp)
 
-**Linux** [example file](examples/linux.cpp)
+**Linux** [example file](examples/mac_and_linux.cpp)
 
-**Mac** [example file](examples/mac.cpp)
+**Mac** [example file](examples/mac_and_linux.cpp)
 
-
-> As of the most recent update, there is no usage example files for Linux or Mac.
 
 
 ### Initialization

--- a/README.md
+++ b/README.md
@@ -1,13 +1,14 @@
 <div align="center">
   <h1 align="center">Aetherim</h1>
 
-  **Aetherim** is the source-code of an internal, injectable DLL that is used to access Unity's IL2CPP methods during run-time. Aetherim should work in both 64-bit and 32-bit programs.
+  **Aetherim** is the source-code of a shared library that is used to access Unity's IL2CPP methods during run-time. Aetherim should work in both 64-bit and 32-bit programs, as well as on Linux, MacOS, and Windows.
 
   I created this in order to learn more about C++ as well as Unity and how its IL2CPP run-time works.
 
   <img src="https://img.shields.io/github/issues/Toxocious/Aetherim?style=for-the-badge&logo=appveyor" />
   <img src="https://img.shields.io/github/forks/Toxocious/Aetherim?style=for-the-badge&logo=appveyor" />
   <img src="https://img.shields.io/github/stars/Toxocious/Aetherim?style=for-the-badge&logo=appveyor" />
+  <br />
   <img src="https://img.shields.io/github/license/Toxocious/Aetherim?style=for-the-badge&logo=appveyor" />
   <a href="https://visitorbadge.io/status?path=https%3A%2F%2Fgithub.com%2FToxocious%Aetherim">
     <img src="https://api.visitorbadge.io/api/visitors?path=https%3A%2F%2Fgithub.com%2FToxocious%Aetherim&countColor=%2337d67a" />
@@ -26,12 +27,12 @@
 
 ## Table of Contents
 - [Table of Contents](#table-of-contents)
-- [About The Project](#about-the-project)
-  - [Tech Stack](#tech-stack)
-  - [Dependencies](#dependencies)
 - [Getting Started](#getting-started)
-  - [Compiling As A DLL](#compiling-as-a-dll)
+  - [Compiling The Library](#compiling-the-library)
+    - [Linux and MacOS](#linux-and-macos)
+    - [Windows](#windows)
 - [Usage In Existing Project](#usage-in-existing-project)
+  - [Basic Wrapper Examples](#basic-wrapper-examples)
   - [Initialization](#initialization)
   - [Getting An Image/DLL](#getting-an-imagedll)
   - [Getting A Class](#getting-a-class)
@@ -49,28 +50,30 @@
 
 
 
-## About The Project
-### Tech Stack
-- C++
-- Premake
-
-### Dependencies
-No dependencies are required.
-
-
 ## Getting Started
-Premake is used to generate the files that are used to compile the code.
+Depending on the operating system that you're using, there's a handful of things to be aware of.
 
-I developed this on Windows and used Premake5 to generate VS2022 solution files to compile.
+Linux and MacOS users have the best ease-of-use and can just run the compile script.
 
-I do not guarantee that this will compile any other way.
+Windows users have a variety of options, all of which require additional tooling to compile the library.
 
-### Compiling As A DLL
-1. Install Premake
-2. Clone this repository
-3. Open the project directory in your terminal
-4. Run ``premake5 <TARGET>``
-5. Open the project file in the appropriate software and compile the .dll
+### Compiling The Library
+There is an included script ([./compile.sh](`compile.sh`)) that should be used to compile the library.
+
+#### Linux and MacOS
+You should be able to simply run the script and the library will be compiled.
+
+#### Windows
+A few different options are open for you.
+
+1. Install [Visual Studio](https://visualstudio.microsoft.com/) and compile through it.
+2. Install [Premake](https://premake.github.io/) and generate a project file, open the project file in the appropriate software, and compile that way.
+3. Install [MinGW](https://www.msys2.org/) and [WSL](https://learn.microsoft.com/en-us/windows/wsl/install) and run the [./compile.sh](`compile.sh`) script.
+
+> Options 1 and 2 have been tested and are confirmed to work; option 3 has not been tested, but should work.
+
+> If you haven't used Linux before or want the most user-friendly method of compilation, I recommend compiling through Visual Studio.
+
 
 
 ## Usage In Existing Project
@@ -95,6 +98,16 @@ If you would like to remove Aetherim from your project, run the following comman
 ```sh
 git rm <path-to-Aetherim>
 ```
+
+### Basic Wrapper Examples
+Included are some very basic examples of how to use this library, all of which can be found in the [./examples](examples/) directory.
+
+**Windows** [example file](examples/windows.cpp)
+**Linux** [example file](examples/linux.cpp)
+**Mac** [example file](examples/mac.cpp)
+
+> As of the most recent update, there is no Linux or Mac example files.
+
 
 ### Initialization
 Be sure to ``#include`` the ``Aetherim/src/wrapper.hpp`` file to your main entrypoint file so that you can access and initialize the IL2CPP wrapper.

--- a/compile.sh
+++ b/compile.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+
+src_dir="src"
+output_dir="output"
+
+compiler="g++"
+
+# Map operating system to output file extension
+case "$(uname -s)" in
+  Linux*) output_ext="so";;
+  Darwin*) output_ext="dylib";;
+  CYGWIN*|MINGW*) output_ext="dll";;
+  *) echo "Unsupported operating system."; exit 1;;
+esac
+
+# Create the output directory if it doesn't exist
+mkdir -p "$output_dir"
+
+# Compile the shared library
+$compiler -shared -o "$output_dir/mylibrary.$output_ext" "$src_dir"/*.{hpp,h}
+
+# Check if compilation was successful
+if [ $? -eq 0 ]; then
+  echo "Compilation successful. The shared library is in $output_dir/mylibrary.$output_ext"
+else
+  echo "Compilation failed."
+fi

--- a/examples/mac_and_linux.cpp
+++ b/examples/mac_and_linux.cpp
@@ -1,0 +1,71 @@
+#if defined( __APPLE__ ) || defined( __linux__ ) || defined( __FreeBSD__ ) || defined( __ANDROID__ )
+
+#  include <iostream>
+#  include <thread>
+#  include <chrono>
+
+#  include "src/wrapper.hpp"
+
+void Init()
+{
+  printf( "[Aetherim] Initializing\n" );
+  Il2cpp::initialize();
+  printf( "[Aetherim] Initialization Complete\n\n" );
+
+  printf( "[Aetherim] Dumping Images\n" );
+  const auto Aetherim = std::make_unique<Wrapper>();
+  printf( "[Aetherim] Images Dumped\n\n" );
+
+  printf( "[Aetherim] Getting Assembly-CSharp Image\n" );
+  const auto image = Aetherim->get_image( "Assembly-CSharp.dll" );
+  printf( "\t[Aetherim] Assembly-CSharp -> %s (0x%zx)\n\n", image->get_name(), reinterpret_cast<uintptr_t>( image ) );
+
+  printf( "[Aetherim] Getting PlayerHandler Class & Fields\n" );
+  const auto player = image->get_class( "PlayerHandler" );
+  printf( "\t[Aetherim] PlayerHandler -> %s (0x%zx)\n\n", player->get_name(), reinterpret_cast<uintptr_t>( player ) );
+
+  for ( const auto field : player->get_fields() )
+  {
+    printf( "\t[Aetherim] PlayerHandler -> %s (0x%zx)\n", field->get_name(), field->get_offset() );
+  }
+
+  const auto player_instance = player->get_field( "Instance" )->get_as_static();
+  if ( player_instance != nullptr )
+    printf( "\t[Aetherim] PlayerHandler -> Static Instance (0x%zx)\n", reinterpret_cast<uintptr_t>( player_instance ) );
+
+  std::this_thread::sleep_for( std::chrono::milliseconds( 60000 ) );
+}
+
+int main()
+{
+  printf( "[Aetherim] Initializing\n" );
+  Il2cpp::initialize();
+  printf( "[Aetherim] Initialization Complete\n\n" );
+
+  printf( "[Aetherim] Dumping Images\n" );
+  const auto Aetherim = std::make_unique<Wrapper>();
+  printf( "[Aetherim] Images Dumped\n\n" );
+
+  printf( "[Aetherim] Getting Assembly-CSharp Image\n" );
+  const auto image = Aetherim->get_image( "Assembly-CSharp.dll" );
+  printf( "\t[Aetherim] Assembly-CSharp -> %s (0x%zx)\n\n", image->get_name(), reinterpret_cast<uintptr_t>( image ) );
+
+  printf( "[Aetherim] Getting PlayerHandler Class & Fields\n" );
+  const auto player = image->get_class( "PlayerHandler" );
+  printf( "\t[Aetherim] PlayerHandler -> %s (0x%zx)\n\n", player->get_name(), reinterpret_cast<uintptr_t>( player ) );
+
+  for ( const auto field : player->get_fields() )
+  {
+    printf( "\t[Aetherim] PlayerHandler -> %s (0x%zx)\n", field->get_name(), field->get_offset() );
+  }
+
+  const auto player_instance = player->get_field( "Instance" )->get_as_static();
+  if ( player_instance != nullptr )
+    printf( "\t[Aetherim] PlayerHandler -> Static Instance (0x%zx)\n", reinterpret_cast<uintptr_t>( player_instance ) );
+
+  std::this_thread::sleep_for( std::chrono::milliseconds( 60000 ) );
+
+  return 0;
+}
+
+#endif

--- a/examples/windows.cpp
+++ b/examples/windows.cpp
@@ -1,6 +1,8 @@
-#include <iostream>
+#if defined( _WIN64 ) || defined( _WIN32 )
 
-#include "src/wrapper.hpp"
+#  include <iostream>
+
+#  include "src/wrapper.hpp"
 
 DWORD WINAPI Init( HMODULE module )
 {
@@ -60,3 +62,5 @@ DWORD WINAPI DllMain( HINSTANCE module, DWORD reason, void * reserved )
 
   return TRUE;
 }
+
+#endif

--- a/src/class.hpp
+++ b/src/class.hpp
@@ -1,6 +1,11 @@
 #pragma once
 
-#include <Windows.h>
+#if defined( _WIN64 ) || defined( _WIN32 )
+#  include <Windows.h>
+#else
+#  include <string.h>
+#endif
+
 #include <stdio.h>
 #include <cstdint>
 #include <iostream>

--- a/src/field.hpp
+++ b/src/field.hpp
@@ -1,6 +1,9 @@
 #pragma once
 
-#include <Windows.h>
+#if defined( _WIN64 ) || defined( _WIN32 )
+#  include <Windows.h>
+#endif
+
 #include <stdio.h>
 #include <cstdint>
 #include <iostream>

--- a/src/method.hpp
+++ b/src/method.hpp
@@ -70,7 +70,7 @@ public:
   auto get_param_name( int index ) const -> const char *
   {
     if ( Il2cpp::get_method_param_name == nullptr || this == nullptr )
-      return false;
+      return "Method->get_param_name() is nullptr";
 
     return Il2cpp::get_method_param_name( this, index );
   }
@@ -81,7 +81,7 @@ public:
   auto get_param_type( int index ) const -> const char *
   {
     if ( Il2cpp::get_method_param_type == nullptr || this == nullptr )
-      return false;
+      return "Method->get_param_type() is nullptr";
 
     return Il2cpp::get_method_param_type( this, index );
   }

--- a/src/method.hpp
+++ b/src/method.hpp
@@ -1,6 +1,9 @@
 #pragma once
 
-#include <Windows.h>
+#if defined( _WIN64 ) || defined( _WIN32 )
+#  include <Windows.h>
+#endif
+
 #include <stdio.h>
 #include <cstdint>
 #include <iostream>

--- a/src/type.hpp
+++ b/src/type.hpp
@@ -1,6 +1,9 @@
 #pragma once
 
-#include <Windows.h>
+#if defined( _WIN64 ) || defined( _WIN32 )
+#  include <Windows.h>
+#endif
+
 #include <stdio.h>
 #include <cstdint>
 #include <iostream>


### PR DESCRIPTION
I've added an example usage file for MacOS and Linux, as well as have update the README to point to the respective example files.

This pull request also includes a fix for some return values in Aetherim's `Method` class, as some return values were incorrect - whoops.

I've also created a bash script that will automatically compile the source code for you once run, compiling to a .dll (Windows), .dylib (MacOS), or .so (Linux) depending on what OS the script is run on.